### PR TITLE
Add Service and fix Ingress for bluearchive-api deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Node.js 22 イメージを使用
+FROM node:22
+
+# 作業ディレクトリ
+WORKDIR /app
+
+# 依存関係をコピーしてインストール
+COPY package*.json ./
+RUN npm install
+
+# アプリケーションコードをコピー
+COPY . .
+
+# ポート指定
+EXPOSE 3000
+
+# アプリ起動
+CMD ["node", "index.js"]

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -17,6 +17,5 @@ spec:
       containers:
         - name: bluearchive-api
           image: kemar1/bluearchiveapi:latest
-          imagePullPolicy: Always
           ports:
             - containerPort: 3000

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bluearchive-api
+  labels:
+    app: bluearchive-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bluearchive-api
+  template:
+    metadata:
+      labels:
+        app: bluearchive-api
+    spec:
+      containers:
+        - name: bluearchive-api
+          image: kemar1/bluearchiveapi:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000

--- a/manifests/ingress.yaml
+++ b/manifests/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: bluearchive-api-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+    - host: ibuki-api-test.uniproject.jp
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: bluearchive-api
+                port:
+                  number: 80

--- a/manifests/ingress.yaml
+++ b/manifests/ingress.yaml
@@ -1,18 +1,19 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: bluearchive-api-ingress
-  annotations:
-    kubernetes.io/ingress.class: nginx
+  name: app-ingress
+  labels:
+    name: app-ingress
 spec:
+  ingressClassName: traefik
   rules:
     - host: ibuki-api-test.uniproject.jp
       http:
         paths:
-          - path: /
-            pathType: Prefix
+          - pathType: Prefix
+            path: "/"
             backend:
               service:
-                name: bluearchive-api
+                name: ibuki-nginx
                 port:
                   number: 80

--- a/manifests/ingress.yaml
+++ b/manifests/ingress.yaml
@@ -1,9 +1,9 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: app-ingress
+  name: bluearchive-api
   labels:
-    name: app-ingress
+    name: bluearchive-api
 spec:
   ingressClassName: traefik
   rules:

--- a/manifests/ingress.yaml
+++ b/manifests/ingress.yaml
@@ -14,6 +14,6 @@ spec:
             path: "/"
             backend:
               service:
-                name: ibuki-nginx
+                name: ibuki-api-test
                 port:
                   number: 80

--- a/manifests/ingress.yaml
+++ b/manifests/ingress.yaml
@@ -14,6 +14,6 @@ spec:
             path: "/"
             backend:
               service:
-                name: ibuki-api-test
+                name: bluearchive-api
                 port:
                   number: 80

--- a/manifests/service.yaml
+++ b/manifests/service.yaml
@@ -9,4 +9,4 @@ spec:
   ports:
     - port: 80
       targetPort: 80
-  type: LoadBalancer
+  type: ClusterIP

--- a/manifests/service.yaml
+++ b/manifests/service.yaml
@@ -8,5 +8,5 @@ spec:
     app: bluearchive-api
   ports:
     - port: 80
-      targetPort: 3000
+      targetPort: 80
   type: LoadBalancer

--- a/manifests/service.yaml
+++ b/manifests/service.yaml
@@ -8,5 +8,5 @@ spec:
     app: bluearchive-api
   ports:
     - port: 80
-      targetPort: 80
+      targetPort: 3000
   type: ClusterIP

--- a/manifests/service.yaml
+++ b/manifests/service.yaml
@@ -3,10 +3,10 @@ kind: Service
 metadata:
   name: bluearchive-api
 spec:
+  ipFamilyPolicy: PreferDualStack
   selector:
     app: bluearchive-api
   ports:
-    - protocol: TCP
-      port: 80
+    - port: 80
       targetPort: 3000
-  type: ClusterIP
+  type: LoadBalancer

--- a/manifests/service.yaml
+++ b/manifests/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bluearchive-api
+spec:
+  selector:
+    app: bluearchive-api
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 3000
+  type: ClusterIP


### PR DESCRIPTION
- Created a ClusterIP Service for bluearchive-api that maps the container's internal port 3000 to port 80 for cluster access.
- Updated the Ingress to point to the new Service, enabling external access through Traefik.
- The Deployment itself remains unchanged; requests are routed Ingress → Service → Pod (port 3000).
- This ensures proper external routing while keeping the application container configuration intact.
