### PR TITLE
Remove clusterIP from postgres service configuration

### DIFF
--- a/manifests/base/postgres-service.yaml
+++ b/manifests/base/postgres-service.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: bluearchive-postgres
 spec:
-  clusterIP: None
   selector:
     app: bluearchive-postgres
   ports:


### PR DESCRIPTION
Removed clusterIP setting from the postgres service.